### PR TITLE
fix python deps for neo-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ bitmath==1.3.1.2
 python_neutronclient==6.5.0
 prompt_toolkit==1.0.15
 python_glanceclient==2.7.0
-requests==2.14.2
+requests==2.18.0
 paramiko==2.4.1
 tabulate==0.8.2
-keystoneauth1==3.7.0
+keystoneauth1==3.8.0
 python_heatclient==1.10.0
 coloredlogs==9.0
 setuptools==37.0.0


### PR DESCRIPTION
Have some errors when try to run neo-cli

Need `request >=2.18.0`
```
student@neocli:~/neo-cli$ source envaja/bin/activate
(envaja) student@neocli:~/neo-cli$ neo --help
Traceback (most recent call last):
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 666, in _build_master
    ws.require(__requires__)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 984, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 875, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (requests 2.14.2 (/home/student/neo-cli/envaja/lib/python3.5/site-packages), Requirement.parse('requests>=2.18.0'), {'oslo.config'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/student/neo-cli/envaja/bin/neo", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3141, in <module>
    @_call_aside
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3125, in _call_aside
    f(*args, **kwargs)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3154, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 668, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 681, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 875, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (requests 2.14.2 (/home/student/neo-cli/envaja/lib/python3.5/site-packages), Requirement.parse('requests>=2.18.0'), {'oslo.config'})
```

need `keystoneauth1`
```
(envaja) student@neocli:~/neo-cli$ neo --help
Traceback (most recent call last):
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 666, in _build_master
    ws.require(__requires__)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 984, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 875, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (keystoneauth1 3.7.0 (/home/student/neo-cli/envaja/lib/python3.5/site-packages), Requirement.parse('keystoneauth1>=3.8.0'), {'openstacksdk'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/student/neo-cli/envaja/bin/neo", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3141, in <module>
    @_call_aside
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3125, in _call_aside
    f(*args, **kwargs)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 3154, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 668, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 681, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/home/student/neo-cli/envaja/lib/python3.5/site-packages/pkg_resources/__init__.py", line 875, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (keystoneauth1 3.7.0 (/home/student/neo-cli/envaja/lib/python3.5/site-packages), Requirement.parse('keystoneauth1>=3.8.0'), {'openstacksdk'})
```